### PR TITLE
Add Android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 30
+    namespace "com.dimitridessus.gaimon"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
Add namespace to Android plugin for AGP 8.0 comaptibility.

See:
https://developer.android.com/build/configure-app-module#groovy
https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#namespace-dsl